### PR TITLE
use priority values from constants for setter value validation

### DIFF
--- a/google/Message.js
+++ b/google/Message.js
@@ -69,8 +69,6 @@ function Message(messageId) {
     this.mBuilded = false;
 }
 
-var Priority = Object.freeze({"NORMAL": 1, "HIGH": 2});
-
 /**
  * Sets the collapseKey property.
  */
@@ -152,10 +150,10 @@ Message.prototype.deliveryReceiptRequested = function (value) {
  */
 Message.prototype.priority = function (value) {
     switch (value) {
-        case Priority.NORMAL:
+        case Constants.MESSAGE_PRIORITY_NORMAL:
             this.mPriority = Constants.MESSAGE_PRIORITY_NORMAL;
             break;
-        case Priority.HIGH:
+        case Constants.MESSAGE_PRIORITY_HIGH:
             this.mPriority = Constants.MESSAGE_PRIORITY_HIGH;
             break;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,20 @@ describe('Message', function () {
             });
         });
     });
+    describe('#priority()', function () {
+        var message
+        beforeEach(function () {
+            message = new Message('test_messageId');
+        });
+        it('should set a valid priority', function () {
+            var prio = 'high';
+            assert.equal(message.priority(prio).getPriority(), prio);
+        });
+        it ('should not set an invalid priority', function () {
+            var prio = 2;
+            assert.notEqual(message.priority(prio).getPriority(), prio);
+        });
+    });
     describe('#build()', function () {
         var message;
         beforeEach(function () {


### PR DESCRIPTION
This allows for usage of the priority setter as described in the README, i.e. `priority` will accept `"high"` and `"normal"` as inputs, instead of the current inputs of `1` and `2`.
