### PR TITLE
xmpp reconnect after WebSocket connection error

### DIFF
--- a/google/Sender.js
+++ b/google/Sender.js
@@ -38,6 +38,7 @@ function Sender(senderID, serverKey, type) {
         password: this.serverKey,
         port: fcmPort,
         host: Constants.FCM_SEND_ENDPOINT,
+        reconnect: true,
         legacySSL: true,
         preferredSaslMechanism: Constants.FCM_PREFERRED_SASL
     });


### PR DESCRIPTION
Allow the XMPP Client to try to reconnect to the Server, if the
WebSocket connection gets disconnected. The client will try to
reconnect according to the default