### PR TITLE
Added mutable-content field support.

### DIFF
--- a/google/Constants.js
+++ b/google/Constants.js
@@ -303,4 +303,10 @@ Constants.JSON_ERROR = "error";
  */
 Constants.JSON_MESSAGE_ID = "message_id";
 
+/**
+ * JSON-only field representing the notification is mutable.
+ * (iOS 10+ rich notification support)
+ */
+Constants.JSON_MUTABLE_CONTENT = "mutable_content"
+
 module.exports = Constants;

--- a/google/Message.js
+++ b/google/Message.js
@@ -65,6 +65,7 @@ function Message(messageId) {
     this.mPriority = null;
     this.mNotification = null;
     this.mContentAvailable = false;
+    this.mMutableContent = false;
 
     this.mBuilded = false;
 }
@@ -172,6 +173,14 @@ Message.prototype.notification = function (value) {
 };
 
 /**
+ * Sets the mutable-content field. (boolean)
+ */
+Message.prototype.mutableContent = function (value) {
+    this.mMutableContent = value;
+    return this;
+};
+
+/**
  * Builds the message and makes its properties immutable.
  */
 Message.prototype.build = function () {
@@ -253,6 +262,13 @@ Message.prototype.getNotification = function () {
     return this.mNotification;
 };
 
+/**
+ * Gets if mutable-content setting for iOS 10+ rich notification.
+ */
+Message.prototype.getMutableContent = function () {
+    return this.mMutableContent;
+};
+
 Message.prototype.toString = function () {
     var builder = "Message['" + this.mMessageId + "'](";
     if (this.mPriority != null) {
@@ -278,6 +294,9 @@ Message.prototype.toString = function () {
     }
     if (this.mNotification != null) {
         builder += "notification: " + this.mNotification + ", ";
+    }
+    if (this.mMutableContent != null) {
+        builder += "mutableContent=" + this.mMutableContent + ", ";
     }
     var hasData = this.mData !== null;
     var data = this.mData;

--- a/google/Sender.js
+++ b/google/Sender.js
@@ -179,6 +179,7 @@ function messageToJson(message, to) {
     setJsonField(jsonMessage, Constants.PARAM_DELAY_WHILE_IDLE, message.isDelayWhileIdle());
     setJsonField(jsonMessage, Constants.PARAM_DRY_RUN, message.isDryRun());
     setJsonField(jsonMessage, Constants.JSON_PAYLOAD, message.getData());
+    setJsonField(jsonMessage, Constants.JSON_MUTABLE_CONTENT, message.getMutableContent());
 
     var notification = message.getNotification();
     if (notification) {


### PR DESCRIPTION
Added mutable-content field for iOS 10+ rich notification. 

* [Related issue](https://github.com/firebase/quickstart-ios/issues/70)
* [FCM reference](https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref)
