### PR TITLE
Enforce string type for messageId

### DIFF
--- a/google/Message.js
+++ b/google/Message.js
@@ -48,7 +48,7 @@ var Constants = require('./Constants');
 
 function Message(messageId) {
 
-    if (util.isNullOrUndefined(messageId)) {
+    if (util.isNullOrUndefined(messageId) || "string" !== typeof(messageId)) {
         throw new IllegalArgumentException();
     }
 


### PR DESCRIPTION
Message sending currently fails with INVALID_JSON if messageId type is something other than string (number etc); string is explicitly required in the FCM XMPP spec.

The resulting nack does not contain a valid message_id as the server does not consider the original message to contain one, so the error is silently dropped by Sender rather than reported as a Result, and is difficult to discover. Enforcing a strict messageId type in the constructor at least ensures that invalid, non-null messageIds are reported as such, rather than silently ignored.

Suspect this may be the cause of #12, if numeric IDs are being used in those cases.